### PR TITLE
Add the "Report-To" header

### DIFF
--- a/resources/headers
+++ b/resources/headers
@@ -58,6 +58,7 @@ Public-Key-Pins-Report-Only
 Range
 Referer~http://%s.%h/
 Referrer-Policy
+Report-To
 Retry-After
 Server
 Set-Cookie


### PR DESCRIPTION
The Report-To header is a feature of CSP 3 that instructs the browser to store CSP violation reporting endpoints for an origin. If this were to be cached, an attacker could insert a malicious report endpoint and start receiving CSP violation reports for the site.