### PR TITLE
Fixed settings dialog not shown whole

### DIFF
--- a/src/burp/Utilities.java
+++ b/src/burp/Utilities.java
@@ -204,7 +204,7 @@ class ConfigurableSettings {
 
     ConfigurableSettings showSettings() {
         JPanel panel = new JPanel();
-        panel.setLayout(new GridLayout(0, 2));
+        panel.setLayout(new GridLayout(0, 4));
 
         HashMap<String, Object> configured = new HashMap<>();
 


### PR DESCRIPTION
Hi,
on smaller monitor sizes you cannot see the whole dialog with settings. That makes param miner almost impossible to use. This is very quick fix I came up with, now it works just fine for me. I don't know whether this was issue for more people, but decided to share anyway - might be useful for someone.