### PR TITLE
Fix Focus Issue

### DIFF
--- a/src/burp/Utilities.java
+++ b/src/burp/Utilities.java
@@ -231,7 +231,7 @@ class ConfigurableSettings {
             }
         }
 
-        int result = JOptionPane.showConfirmDialog(Utilities.getBurpFrame(), panel, "Attack Config", JOptionPane.OK_CANCEL_OPTION, JOptionPane.PLAIN_MESSAGE);
+        int result = JOptionPane.showConfirmDialog(null, panel, "Attack Config", JOptionPane.OK_CANCEL_OPTION, JOptionPane.PLAIN_MESSAGE); // setting parent frame to null, otherwise the dialog has no focus
         if (result == JOptionPane.OK_OPTION) {
             for(String key: configured.keySet()) {
                 Object val = configured.get(key);


### PR DESCRIPTION
Previously, one had to obtain focus on the opened dialogue by clicking somewhere before being able to interact with the elements (button, checkbox) etc. 
In a nutshell, one had to click buttons twice to exit the menu again, for example.