### PR TITLE
Print url instead of host

### DIFF
--- a/src/burp/ParamAttack.java
+++ b/src/burp/ParamAttack.java
@@ -103,7 +103,7 @@ class ParamAttack {
         this.stop = stop;
         this.config = config;
         this.baseRequestResponse = baseRequestResponse;
-        targetURL = baseRequestResponse.getHttpService().getHost();
+        targetURL = Utilities.analyzeRequest(baseRequestResponse).getUrl().toString();
         params = calculatePayloads(baseRequestResponse, paramGrabber, type);
         valueParams = new ArrayList<>();
         for(int i = 0; i< params.size(); i++) {


### PR DESCRIPTION
Hi, not sure how others feel, but I was tired of trying to remember what was the endpoint I ran param miner against, it was printing:
```
Resuming url bruteforce at -1 on target.com
```

I changed it to:
```
Resuming url bruteforce at -1 on https://target.com/some/path?a=b
```
It was just one line of code changed, hope it was not enough to break something. As far I can tell, the field is only used for print so it should be ok.