### PR TITLE
Bugfix for canSeeCache when request is null

### DIFF
--- a/src/burp/ParamGuesser.java
+++ b/src/burp/ParamGuesser.java
@@ -2,9 +2,6 @@ package burp;
 
 import org.apache.commons.collections4.queue.CircularFifoQueue;
 
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.PrintWriter;
 import java.util.*;
 import java.util.concurrent.ThreadPoolExecutor;
 
@@ -590,6 +587,10 @@ class ParamGuesser implements Runnable {
 
 
     private static boolean canSeeCache(byte[] response) {
+        if(response == null){
+            Utilities.out("WARNING: canSeeCache() cannot check headers of null response");
+            return false;
+        }
         String[] headers = new String[]{"Age", "X-Cache", "Cache", "X-Cache-Hits", "X-Varnish-Cache", "X-Drupal-Cache", "X-Varnish", "CF-Cache-Status", "CF-RAY"};
         for(String header: headers) {
             if(Utilities.getHeaderOffsets(response, header) != null) {


### PR DESCRIPTION
This is a bugfix for #55 .
Somehow a nullpointer is passed to canSeeCache so I just null check it. I don't have time to see why that's happening and maybe you would be more able to figure that out when you have time but this fix works and allows the attack to complete for the moment.
I have also added an error message for when this happens so that it isn't silently ignored.