### PR TITLE
Add Fetch Metadata and User-Agent Client Hints to the list of headers

### DIFF
--- a/resources/headers
+++ b/resources/headers
@@ -781,6 +781,10 @@ redirect-proxy
 redirect-temp
 refferer
 requesttoken
+sec-fetch-dest
+sec-fetch-mode
+sec-fetch-site
+sec-fetch-user
 sec-websocket-key
 sp-host
 ssl

--- a/resources/headers
+++ b/resources/headers
@@ -781,6 +781,14 @@ redirect-proxy
 redirect-temp
 refferer
 requesttoken
+sec-ch-ua
+sec-ch-ua-arch
+sec-ch-ua-bitness
+sec-ch-ua-full-version-list
+sec-ch-ua-mobile
+sec-ch-ua-model
+sec-ch-ua-platform
+sec-ch-ua-platform-version
 sec-fetch-dest
 sec-fetch-mode
 sec-fetch-site


### PR DESCRIPTION
Fetch Metadata request headers are interesting candidate headers for Web cache poisoning. [Section 5.1 of the Fetch Metadata Request Headers W3C Working Draft][fetch-metadata-wd-vary] states:

> If a given endpoint’s response depends upon the values the client delivers
> in a Fetch metadata header, developers should be careful to include an
> appropriate `Vary` header [RFC7231], in order to ensure that caches handle
> the response appropriately. For example, `Vary: Accept-Encoding, Sec-Fetch-Site`.

So are User-Agent Client Hints. [Section 3.2 of RFC 8942][rfc-8942-3.2] states:

> When selecting a response based on one or more Client Hints, and if
> the resource is cacheable, the server needs to generate a `Vary`
> response header field [RFC7234] to indicate which hints can affect
> the selected response and whether the selected response is
> appropriate for a later request.

[fetch-metadata-wd-vary]: https://www.w3.org/TR/fetch-metadata/#vary
[rfc-8942-3.2]: https://datatracker.ietf.org/doc/html/rfc8942#section-3.2

See also https://twitter.com/jub0bs/status/1466728891758882816