### PR TITLE
Adds X-Amz-Server-Side-Encryption

### DIFF
--- a/resources/headers
+++ b/resources/headers
@@ -669,6 +669,7 @@ viad
 x
 x-access-token
 x-amz-date
+x-amz-server-side-encryption
 x-auth-key
 x-auth-user
 x-confirm-delete


### PR DESCRIPTION
Adding `X-Amz-Server-Side-Encryption` header.

Source: [Attacking AWS CloudFront](https://bxmbn.medium.com/attacking-aws-cloudfront-cdn-19a96d5c0615)