### PR TITLE
Add "_username" and "_switch_user" param names

### DIFF
--- a/resources/params
+++ b/resources/params
@@ -6521,3 +6521,4 @@ adminCookie
 fullapp
 LandingUrl
 _username
+_switch_user

--- a/resources/params
+++ b/resources/params
@@ -6520,3 +6520,4 @@ user_token
 adminCookie
 fullapp
 LandingUrl
+_username


### PR DESCRIPTION
Hi,

I proposed adding the parameters, named `_username` and `_switch_user`, to the *params* dictionary. I added them at the end of the file to not affect any specific ordering used.

I seen them used in web app using the [Symfony](https://symfony.com/doc/current/security.html#form-login) PHP framework.

🌎 Additional sources used:

* https://symfonycasts.com/screencast/symfony-security/form-login#customizing-the-login-form-field-names
* https://github.com/symfony/symfony/blob/a3686fbfbbbfec317213f831eabeb5a450720545/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/FormLoginFactory.php#L32
* https://symfony.com/doc/current/security/impersonating_user.html

Thanks a lot in advance 😃 
