### PR TITLE
fix(OfferParamGuess): remove duplicate GET parameters scan from guess everything

### DIFF
--- a/src/burp/OfferParamGuess.java
+++ b/src/burp/OfferParamGuess.java
@@ -39,7 +39,6 @@ class OfferParamGuess implements IContextMenuFactory {
         JMenu scanMenu = new JMenu("Guess params");
 
         JMenuItem allButton = new JMenuItem("Guess everything!");
-        allButton.addActionListener(new TriggerParamGuesser(reqs, false, IParameter.PARAM_URL, paramGrabber, taskEngine));
         
         JMenuItem probeButton = new JMenuItem("Guess GET parameters");
         probeButton.addActionListener(new TriggerParamGuesser(reqs, false, IParameter.PARAM_URL, paramGrabber, taskEngine));


### PR DESCRIPTION
Previously `Guess everything!` was running param guesser twice for URL params:
- `PARAM_URL`
- `PARAM_URL`
- `PARAM_COOKIE`
- `PARAM_HEADER`