### PR TITLE
Fix in columbus-elmasy collection

### DIFF
--- a/src/burp/Lensmine.java
+++ b/src/burp/Lensmine.java
@@ -43,7 +43,7 @@ public class Lensmine extends Scan {
             try {
                 String url = "https://columbus.elmasy.com/api/lookup/" + domain;
                 HttpRequestResponse apiResp = Utilities.montoyaApi.http().sendRequest(HttpRequest.httpRequestFromUrl(url).withHeader("Accept", "text/plain"), RequestOptions.requestOptions().withUpstreamTLSVerification());
-                subdomainProvider.addSourceWords(apiResp.response().toString());
+                subdomainProvider.addSourceWords(apiResp.response().bodyToString());
             } catch (Exception e) {
                 Utilities.out("External subdomain lookup failed: "+e.toString());
             }


### PR DESCRIPTION
The issue is related to the `external subdomain lookup` functionality. This is a small fix to only include subdomain results retrieved from columbus.elmasy.com in the words to test. More specifically, this line:
```Java
subdomainProvider.addSourceWords(apiResp.response().toString());
```
This line passes the entire response of columbus-elmasy as a wordlist, including the response headers. This results in several false positives during test. Assuming a response from columbus-elmasy.com such as the following:
```http
HTTP/2 200 OK
Server: nginx
Content-Type: text/plain; charset=utf-8
Date: Sun, 08 Sep 2024 08:14:37 GMT
Vary: Accept-Encoding
Cache-Control: public, max-age=600, must-revalidate, stale-if-error=604800
Expires: Sun, 08 Sep 2024 08:24:37 UTC
Vary: Accept
Strict-Transport-Security: max-age=63072000
Access-Control-Allow-Origin: *

academy
acpt
acpt.az
adfs
```

During the exploitation phase against the domain in question, this results in requests such as the following:
```http
GET / HTTP/2
Host: HTTP/2 200 OK.example.com
User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.6367.60 Safari/537.36
```
```http
GET / HTTP/2
Host: Server: nginx.example.com
User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.6367.60 Safari/537.36
```
```http
GET / HTTP/2
Host: Content-Type: text/plain; charset=utf-8.example.com
User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.6367.60 Safari/537.36
```

Notice the subdomain part in the `Host` headers. The fix is pretty straightforward, simply changing `.toString()` to `.bodyToString()` to only parse the response body.
```Java
subdomainProvider.addSourceWords(apiResp.response().bodyToString());
```

Cheers!