### PR TITLE
Fix for OfferHostnameOverride

### DIFF
--- a/src/burp/OfferHostnameOverride.java
+++ b/src/burp/OfferHostnameOverride.java
@@ -16,9 +16,6 @@ public class OfferHostnameOverride  implements ContextMenuItemsProvider {
     public List<Component> provideMenuItems(ContextMenuEvent event)
     {
         List<Component> menuItemList = new ArrayList<>();
-        if (event.selectedRequestResponses().isEmpty()) {
-            return menuItemList;
-        }
         
         HttpRequestResponse requestResponse = event.messageEditorRequestResponse().isPresent() ? event.messageEditorRequestResponse().get().requestResponse() : event.selectedRequestResponses().get(0);
         String serviceHost = requestResponse.httpService().host();
@@ -41,7 +38,7 @@ public class OfferHostnameOverride  implements ContextMenuItemsProvider {
             return;
         }
         String json = "{\"enabled\":true,\"hostname\":\""+hostHeader+"\",\"ip_address\":\""+ipAddress+"\"}"; // {"project_options":{"connections":{"hostname_resolution":[     ]}}}
-        String currentSettings = Utilities.montoyaApi.burpSuite().exportProjectOptionsAsJson("project_options.connections.hostname_resolution");
+        String currentSettings = Utilities.montoyaApi.burpSuite().exportProjectOptionsAsJson("project_options.dns.hostname_resolution");
         if (currentSettings.contains("ip_address")) {
             json = currentSettings.replace("]", ","+json+"]");
         } else {


### PR DESCRIPTION
Hey there!

In the latest Burp Suite the menu option for `Hostname resolution overrides` has been moved from `Project Options -> Network -> Connections` to `Project Options -> Network -> DNS`. This causes the context menu option for `Route requests to X via Y` to not work properly as the project option edit was attempting to insert the option to a wrong place. 
This was fixed by changing the following:
```Java
String currentSettings = Utilities.montoyaApi.burpSuite().exportProjectOptionsAsJson("project_options.connections.hostname_resolution");
```
to
```Java
String currentSettings = Utilities.montoyaApi.burpSuite().exportProjectOptionsAsJson("project_options.dns.hostname_resolution");
```

Additionally, I took the liberty of removing the following piece of code:
```Java
if (event.selectedRequestResponses().isEmpty()) {
    return menuItemList;
}
```
I noticed that this was added at some point, however I didn't understand why. This piece of code removed the context menu from locations such as the Repeater and only makes it appear in grid-like places like the Organizer. Having the context menu appear in Repeater is really helpful at least for me and I believe it is a more generic usability approach. Really curious about the reasoning behind this :P 

Cheers!