### PR TITLE
Add the option to send HTTP headers in Hyphenated-Pascal-Case instead…

### DIFF
--- a/src/burp/BurpExtender.java
+++ b/src/burp/BurpExtender.java
@@ -79,6 +79,7 @@ public class BurpExtender implements IBurpExtender, IExtensionStateListener, Bur
         guessSettings.register("max bucketsize", 65536, "Maximum number of parameters Param Miner will consider putting in a single request if the server allows it.");
         guessSettings.register("max param length", 32, "This is used alongside the bucketsize detection");
         guessSettings.register("lowercase headers", true, "Send header names in lowercase. Good for efficiency.");
+        guessSettings.register("include Hyphenated-Pascal-Case headers", false, "Include headers in Hyphenated-Pascal-Case to account for case sensitive HTTP header parsing (e.g. x-forwarded-for is also sent as X-Forwarded-For). This setting ignores `lowercase headers`.");
         guessSettings.register("name in issue", false, "Include the parameter name in the issue title");
         guessSettings.register("canary", "zwrtxqva", "Fixed prefix used to detect input reflection");
         guessSettings.register("force canary", "", "Use this to override the canary - useful with carpet bomb mode");

--- a/src/burp/ParamHolder.java
+++ b/src/burp/ParamHolder.java
@@ -28,6 +28,22 @@ class ParamHolder {
         paramBuckets.push(e);
     }
 
+    String toHyphenatedPascalCaseIgnorePercent(String s) {
+        StringBuilder b = new StringBuilder(s.length());
+
+        for (int i = 0; i < s.length(); i++) {
+            char c = s.charAt(i);
+
+            // Do not capitalize the character after a percentage sign. This is used for string interpolation by the extension to add IP and Port information to HTTP headers
+            if (i == 0 || (!Character.isLetterOrDigit(s.charAt(i-1)) && s.charAt(i-1) != '%')) {
+                b.append(Character.toUpperCase(c));   
+            } else {
+                b.append(c);
+            }
+        }
+        return b.toString();
+    }
+
     void addParams(ArrayList<String> params, boolean topup) {
         removeBadEntries(params);
 
@@ -48,6 +64,18 @@ class ParamHolder {
                 }
                 else {
                     params.add("x-"+param);
+                }
+            }
+
+            if (BulkUtilities.globalSettings.getBoolean("include Hyphenated-Pascal-Case headers")) {
+                max = params.size();
+                params.ensureCapacity(max*2);
+                for (int i=0; i<max; i++) {
+                    String param = params.get(i);
+                    String pascalCaseParam = toHyphenatedPascalCaseIgnorePercent(param);
+                    if (!pascalCaseParam.equals(param)) {
+                        params.add(pascalCaseParam);
+                    }
                 }
             }
         }


### PR DESCRIPTION
Although HTTP/1.1 headers are defined to be case in-sensitive (ref 1), webserver implementations could deviate from the standard and match HTTP/1.1 headers with case sensitivity. The implementation of Param Miner currently cannot account for this as it sends all headers in lowercase regardless of whether the `lowercase headers` configuration option is set. If, for example, a webserver expects `X-Forwarded-Host` case sensitively, the header `x-forwarded-host` sent by Param Miner will not match. This could therefore lead to false negatives.

My pull request adds another configuration option to the Guess Headers scan: "include Hyphenated-Pascal-Case headers". For every header, it creates a duplicate header in Hyphenated-Pascal-Case format. Because roughly twice the amount of headers are sent, the configuration option is set to `false` by default.

The modified code successfully compiles, it runs in the latest version of Burp and it is now also able to detect hidden headers for servers that are case sensitive.

I am looking forward to any feedback or suggestions.

References:
1. https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers
