### PR TITLE
Update headers

### DIFF
--- a/resources/headers
+++ b/resources/headers
@@ -3,6 +3,7 @@ accept-charset
 accept-encoding
 accept-language
 accept-ranges
+x-middleware-subrequest
 access-control-allow-credentials
 access-control-allow-headers
 access-control-allow-methods


### PR DESCRIPTION
Considering how large the NextJS CVE-2025-29927 I think it should be added.

https://projectdiscovery.io/blog/nextjs-middleware-authorization-bypass