### PR TITLE
Add option to log cachebuster-mutated requests for reproducible PoCs

### DIFF
--- a/src/burp/BurpExtender.java
+++ b/src/burp/BurpExtender.java
@@ -38,6 +38,7 @@ public class BurpExtender implements IBurpExtender, IExtensionStateListener, Bur
         // config only (currently param-guess displays everything)
         configSettings.register("Add 'fcbz' cachebuster", false, "Add a static cache-buster to all outbound requests, to avoid manual cache poisoning probes affecting other users");
         configSettings.register("Add dynamic cachebuster", false, "Add a dynamic cache-buster to all requests, to avoid seeing cached responses");
+        configSettings.register("Log mutated requests", false, "When Param Miner mutates an outbound request (e.g. cachebusters), log the final request bytes for reproducible PoCs");
         //configSettings.register("Add header cachebuster", false);
         configSettings.register("learn observed words", false, "During Burp's passive scanning, record all words seen in the response and use them when guessing parameters. ");
         configSettings.register("enable auto-mine", false, "Automatically launch param guessing attacks on traffic as it passes through the proxy");

--- a/src/burp/ParamGrabber.java
+++ b/src/burp/ParamGrabber.java
@@ -94,6 +94,22 @@ public class ParamGrabber implements IProxyListener, IHttpListener {
         }
 
         messageInfo.setRequest(req);
+
+        if (cacheBuster != null && BulkUtilities.globalSettings.getBoolean("Log mutated requests")) {
+            try {
+                IRequestInfo ri = BulkUtilities.helpers.analyzeRequest(messageInfo.getHttpService(), req);
+                java.net.URL url = ri.getUrl();
+
+                BulkUtilities.out("=== Param Miner mutated request ===");
+                BulkUtilities.out("URL: " + url);
+                BulkUtilities.out("Cachebuster: " + cacheBuster);
+                BulkUtilities.out("-----------------------------------");
+                BulkUtilities.out(BulkUtilities.helpers.bytesToString(req));
+                BulkUtilities.out("=== end ===");
+            } catch (Exception e) {
+                BulkUtilities.out("Param Miner: failed to log mutated request: " + e);
+            }
+        }
     }
 
     private void launchScan(IHttpRequestResponse messageInfo) {


### PR DESCRIPTION
This PR adds a new optional setting: **Log mutated requests**.

When enabled, Param Miner logs the final outbound request after cachebuster mutations, including:
- Reconstructed URL
- Cachebuster token
- Full raw HTTP request

This makes cache poisoning testing reproducible, as cachebuster mutations are otherwise opaque during manual testing.

The feature is fully opt-in and introduces no behavioral or performance impact unless explicitly enabled.

### Testing
- Tested in Burp Suite Community Edition 2026.1.5 (macOS & Linux)
- Verified logging output shows URL, cachebuster value and final mutated request