### PR TITLE
Fix Lensmine.getTitle() to correctly extract page titles

### DIFF
--- a/src/burp/Lensmine.java
+++ b/src/burp/Lensmine.java
@@ -17,6 +17,7 @@ import org.apache.commons.lang3.StringUtils;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.*;
+import java.util.regex.*;
 
 public class Lensmine extends Scan {
 
@@ -337,10 +338,16 @@ public class Lensmine extends Scan {
     static String getTitle(HttpRequestResponse resp) {
         try {
             String body = resp.response().bodyToString();
-            if (!body.contains("<title")) {
-                return "";
+
+            Pattern p = Pattern.compile("<title>(.*?)</title>", Pattern.CASE_INSENSITIVE | Pattern.DOTALL);
+            Matcher m = p.matcher(body);
+
+            if (m.find()) {
+                return m.group(1).trim();
             }
-            return body.split("<title", 1)[1].split(">", 1)[1].split("<")[0];
+
+            return "";
+
         } catch (Exception e) {
             return "";
         }


### PR DESCRIPTION
### The problem
While using param-miner for Host header / subdomain routing detection, I encountered a case where a valid internal host was being skipped as a false negative compared to manual equivalent testing. The issue was pretty much the following:
* A random subdomain returned the default IIS page
* A valid subdomain returned a different application page
* Both responses had identical status, and headers
* Only the <title> differed

However, the fingerprint generated by Lensmine.calculateFingerprint() contained an empty "title" field for both responses, causing CustomResponseGroup.matches() to treat them as identical and skip the finding.

This led me to investigate Lensmine.getTitle().

### Current implementation:
The following code is being used to extract the title of the response:
```Java
return body.split("<title", 1)[1].split(">", 1)[1].split("<")[0];
```
This has 2 problems: 
1. `String.split(pattern, 1)` in Java does not perform a split but rather returns the entire string, which causes trying to retrieve `body.split("<title", 1)[1]` from it to raise an index out of bounds exception, effectively falling back to the empty string of the exception handling. 
2. This approach is case-sensitive.

### Proposed fix
Changing the extraction code to a regex-based approach solves both issues. Here is the code:
```Java
Pattern p = Pattern.compile("<title>(.*?)</title>", Pattern.CASE_INSENSITIVE | Pattern.DOTALL);
Matcher m = p.matcher(body);

if (m.find()) {
    return m.group(1).trim();
}
```
What this fix does:
- Fixes the existing problem with titles not being extracted
- Is case-incensitive
- Handles multi-line title tags for whatever reason
- Preserves existing behavior for fingerprint extraction

### Verification
The fix has been verified in my test case and works as expected.
Test case:
```
Random host -> IIS default page -> title = "IIS Windows Server"
Valid host  -> application page -> title = "Internal System"
```

Before fix:
```
title = ""
title = ""
-> responses considered identical
-> finding skipped
```

After fix:
```
title = "IIS Windows Server"
title = "Internal System"
-> fingerprints differ
-> finding detected
```

Keep up the awesome work! Cheers!