### PR TITLE
Fix NullPointerException when Host header is lowercase

### DIFF
--- a/src/burp/BurpExtender.java
+++ b/src/burp/BurpExtender.java
@@ -247,7 +247,7 @@ class ParamNameInsertionPoint extends ParamInsertionPoint {
         present = new HashMap<>();
         List<String> headers = BulkUtilities.analyzeRequest(request).getHeaders();
         for (String header: headers) {
-            if (header.startsWith("Host: ")) {
+            if (header.toLowerCase().startsWith("host: ")) {
                 host = header.split(": ", 2)[1];
             }
             header = header.split(": ", 2)[0];


### PR DESCRIPTION
## Summary

Param Miner currently only recognizes the `Host` header when it is written as `Host: `.

When running Guess Headers against an HTTP/1.1 request that uses a lowercase `host` header, the host value is not extracted correctly, which later results in a `NullPointerException`.

This change makes the Host header lookup case-insensitive so that requests using `host:` are handled correctly.

## Reproduction

Run Guess Headers against the following request:

```
GET / HTTP/1.1
host: localhost
```

The extension throws the following exception:
```
java.lang.NullPointerException: Cannot invoke "java.lang.CharSequence.toString()" because "replacement" is null
	at java.base/java.lang.String.replace(String.java:3151)
	at burp.ParamNameInsertionPoint.getValue(BurpExtender.java:341)
    ...
```
## Root Cause

The code only checks for headers beginning with `Host: `:
```
if (header.startsWith("Host: ")) {
```
HTTP header field names are case-insensitive, so requests using `host:` are not recognized. As a result, the host variable remains unset and a `NullPointerException` occurs later during header guessing.

## Fix

Perform a case-insensitive match when extracting the Host header value.