### PR TITLE
Add new param name about WSDL.

### DIFF
--- a/resources/params
+++ b/resources/params
@@ -6520,6 +6520,7 @@ user_token
 adminCookie
 fullapp
 LandingUrl
+singleWsdl
 _username
 _switch_user
 _json


### PR DESCRIPTION
Hi,

I discovered a new parameter name that is used to get the WSDL of a SOAP service: `singleWsdl`.

<img width="1049" height="205" alt="image" src="https://github.com/user-attachments/assets/9d4e629a-206a-435a-881b-b8356c01972d" />

So I propose it for the `params` dictionary 😊
