### PR TITLE
Add @type to resources/params

### DIFF
--- a/resources/params
+++ b/resources/params
@@ -6526,3 +6526,4 @@ _switch_user
 _json
 _rsc
 __nextDataReq
+@type


### PR DESCRIPTION
Hi,

This PR propose to add the parameter named `@type`.

I discovered it via the [FastJson 1.2.83 Remote Code Execution](https://fearsoff.org/research/fastjson-1-2-83-rce) recent vulnerability through the dedicated lab of [PentesterLab](https://pentesterlab.com/exercises/fastjson-jsontype-rce).

It can be interesting when searching for hidden params in a json content.